### PR TITLE
custom prompt

### DIFF
--- a/utils/shared_functions.py
+++ b/utils/shared_functions.py
@@ -40,12 +40,14 @@ def get_answer_from_document(message, index_name, namespace):
 
     # Create the retrieval chain
     custom_prompt = """You are a helpful assistant that answers questions based on provided context.
+
+    Try to include links to files or documents if the context contains them.
     
     <context>
     {context}
     </context>
     
-    Answer the question based on the context. If you cannot find the answer in the context, say "I cannot find the answer in the provided context." Do not make up information."""
+    Answer the question based on the context. If you cannot find the answer in the context, say "Я не могу ответить в рамках моих знаний." Do not make up information."""
 
     retrieval_qa_chat_prompt = ChatPromptTemplate.from_messages([
         ("system", custom_prompt),

--- a/utils/shared_functions.py
+++ b/utils/shared_functions.py
@@ -2,6 +2,7 @@ import os
 from chatgpt_md_converter import telegram_format
 from langchain_pinecone import PineconeEmbeddings, PineconeVectorStore
 from langchain_openai import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
 from langchain.chains import create_retrieval_chain
 from langchain.chains.combine_documents import create_stuff_documents_chain
 from langchain import hub
@@ -38,7 +39,19 @@ def get_answer_from_document(message, index_name, namespace):
     )
 
     # Create the retrieval chain
-    retrieval_qa_chat_prompt = hub.pull("langchain-ai/retrieval-qa-chat")
+    custom_prompt = """You are a helpful assistant that answers questions based on provided context.
+    
+    <context>
+    {context}
+    </context>
+    
+    Answer the question based on the context. If you cannot find the answer in the context, say "I cannot find the answer in the provided context." Do not make up information."""
+
+    retrieval_qa_chat_prompt = ChatPromptTemplate.from_messages([
+        ("system", custom_prompt),
+        ("user", "{input}"),
+    ])
+    
     combine_docs_chain = create_stuff_documents_chain(
         llm, retrieval_qa_chat_prompt
     )


### PR DESCRIPTION
Fixes: #2 

Вместо шаблонного промпта `langchain-ai/retrieval-qa-chat` (см https://smith.langchain.com/hub/langchain-ai/retrieval-qa-chat) используется кастомный. И в нем добавлена строчка о том, чтобы по возможности включать ссылки на файлы.

